### PR TITLE
automatically use required_version from terraform section of tf files

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ which tfenv
 
 Install a specific version of Terraform.
 
-If no parameter is passed, the version to use is resolved automatically via [.terraform-version files](#terraform-version-file) or [TFENV\_TERRAFORM\_VERSION environment variable](#tfenv_terraform_version) (TFENV\_TERRAFORM\_VERSION takes precedence), defaulting to 'latest' if none are found.
+If no parameter is passed, the version to use is resolved automatically via [TFENV\_TERRAFORM\_VERSION environment variable](#tfenv_terraform_version), [.terraform-version files](#terraform-version-file), or [required_version in "terraform" section of any .tf or .tf.json file](#min-required), in that order of precedence, i.e. TFENV\_TERRAFORM\_VERSION, then .terraform-version, and then required_version in .tf. The default is 'latest' if none are found.
 
 If a parameter is passed, available options:
 

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -73,8 +73,8 @@ declare regex="${resolved##*\:}";
 
 log 'debug' "Processing install for version ${version}, using regex ${regex}";
 
-version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)";
-[ -n "${version}" ] || log 'error' "No versions matching '${requested}' found in remote";
+remote_version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)";
+[ -n "${remote_version}" ] && version="${remote_version}" || log 'error' "No versions matching '${requested:-$version}' found in remote";
 
 dst_path="${TFENV_CONFIG_DIR}/versions/${version}";
 if [ -f "${dst_path}/terraform" ]; then
@@ -176,11 +176,14 @@ download_signature() {
 };
 
 # If on MacOS with Homebrew, use GNU grep
-# This allows keybase login detection to work on Mac
+# This allows keybase login detection to work on Mac,
+# and is required to be able to detect terraform version
+# from "required_version" setting in "*.tf" files
 if [[ $(uname) == 'Darwin' ]] && [ $(which brew) ]; then
   if ! [ $(which ggrep) ]; then
     brew install grep;
   fi
+  shopt -s expand_aliases
   alias grep=ggrep;
 fi
 

--- a/libexec/tfenv-resolve-version
+++ b/libexec/tfenv-resolve-version
@@ -57,6 +57,17 @@ for dir in libexec bin; do
   esac;
 done;
 
+# If on MacOS with Homebrew, use GNU grep
+# This allows keybase login detection to work on Mac,
+# and is required to be able to detect terraform version
+# from "required_version" setting in "*.tf" files
+if [[ $(uname) == 'Darwin' ]] && [ $(which brew) ]; then
+  if ! [ $(which ggrep) ]; then
+    brew install grep;
+  fi
+  shopt -s expand_aliases
+  alias grep=ggrep;
+fi
 #####################
 # Begin Script Body #
 #####################
@@ -73,19 +84,41 @@ if [ -z "${arg}" -a -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
     log 'debug' "Version File (${version_file}) is not the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version)";
     version_requested="$(cat "${version_file}")" \
       || log 'error' "Failed to open ${version_file}";
+  fi;
 
-  elif [ -f "${version_file}" ]; then
+  if [ -z "${version_requested:-""}" ]; then
+    log 'debug' 'Tryng to set version from "required_version" under "terraform" section'
+    versions="$( echo $(cat {*.tf,*.tf.json} 2>/dev/null | grep -h required_version) | grep  -o '\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
+    if [[ "${versions}" =~ ([~=!<>]{0,2}[[:blank:]]*[0-9]+[0-9.]+)[^0-9]*(-[a-z]+[0-9]+)? ]]; then
+      found_min_required="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+      if [[ "${found_min_required}" =~ ^!=.+ ]]; then
+        log 'debug' "required_version is a negation - we cannot guess the desired one, skipping.";
+      else
+        found_min_required="$(echo "$found_min_required")";
+
+        # Probably not an advisable way to choose a terraform version,
+        # but this is the way this functionality works in terraform:
+        # add .0 to versions without a minor and/or patch version (e.g. 12.0)
+        while ! [[ "${found_min_required}" =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; do
+          found_min_required="${found_min_required}.0";
+        done;
+        version_requested="${found_min_required}";
+      fi;
+    fi;
+  fi;
+
+  if [ -z "${version_requested}" -a -f "${version_file}" ]; then
     log 'debug' "Version File is the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version)";
     version_requested="$(cat "${version_file}")" \
       || log 'error' "Failed to open ${version_file}";
 
-    # Absolute fallback
     if [ -z "${version_requested}" ]; then
       log 'debug' 'Version file had no content. Falling back to "latest"';
       version_requested='latest';
     fi;
 
-  else
+  # Absolute fallback
+  elif [ -z "${version_requested}" ]; then
     log 'debug' "Version File is the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version) but it doesn't exist";
     log 'info' 'No version requested on the command line or in the version file search path. Installing "latest"';
     version_requested='latest';

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -79,6 +79,7 @@ log debug "Resolving version with: tfenv-resolve-version ${requested_arg}";
 declare resolved="$(tfenv-resolve-version ${requested_arg})";
 log debug "Resolved to: ${resolved}";
 
+declare requested_version="${resolved%%\:*}";
 declare version="${resolved%%\:*}";
 declare regex="${resolved##*\:}";
 
@@ -92,7 +93,7 @@ declare version="$(\find "${TFENV_CONFIG_DIR}/versions/" -type d -exec basename 
 
 [ -n "${version}" ] \
   && log 'debug' "Found version: ${version}" \
-  || log 'error' "No installed versions of terraform matched '${requested}'${version_source_suffix}";
+  || log 'error' "No installed versions of terraform matched '${requested_version}'${version_source_suffix}";
 
 target_path="${TFENV_CONFIG_DIR}/versions/${version}";
 [ -f "${target_path}/terraform" ] \

--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -56,6 +56,18 @@ for dir in libexec bin; do
   esac;
 done;
 
+# If on MacOS with Homebrew, use GNU grep
+# This allows keybase login detection to work on Mac,
+# and is required to be able to detect terraform version
+# from "required_version" setting in "*.tf" files
+if [[ $(uname) == 'Darwin' ]] && [ $(which brew) ]; then
+  if ! [ $(which ggrep) ]; then
+    brew install grep;
+  fi
+  shopt -s expand_aliases
+  alias grep=ggrep;
+fi
+
 #####################
 # Begin Script Body #
 #####################
@@ -65,10 +77,36 @@ if [[ -z "${TFENV_TERRAFORM_VERSION:-""}" ]]; then
     && log 'debug' "TFENV_VERSION_FILE retrieved from tfenv-version-file: ${TFENV_VERSION_FILE}" \
     || log 'error' 'Failed to retrieve TFENV_VERSION_FILE from tfenv-version-file';
 
-  TFENV_VERSION="$(cat "${TFENV_VERSION_FILE}" || true)" \
-    && log 'debug' "TFENV_VERSION specified in TFENV_VERSION_FILE: ${TFENV_VERSION}";
+  if [ "${TFENV_VERSION_FILE}" = "${TFENV_CONFIG_DIR}/version" ]; then
+    log 'debug' 'Tryng to set version from "required_version" under "terraform" section'
 
-  TFENV_VERSION_SOURCE="${TFENV_VERSION_FILE}";
+    versions="$( echo $(cat {*.tf,*.tf.json} 2>/dev/null | grep -h required_version) | grep  -o '\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
+    if [[ "${versions}" =~ ([~=!<>]{0,2}[[:blank:]]*[0-9]+[0-9.]+)[^0-9]*(-[a-z]+[0-9]+)? ]]; then
+      found_min_required="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+      if [[ "${found_min_required}" =~ ^!=.+ ]]; then
+        log 'debug' "required_version is a negation - we cannot guess the desired one, skipping.";
+      else
+        found_min_required="$(echo "$found_min_required")";
+
+        # Probably not an advisable way to choose a terraform version,
+        # but this is the way this functionality works in terraform:
+        # add .0 to versions without a minor and/or patch version (e.g. 12.0)
+        while ! [[ "${found_min_required}" =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; do
+          found_min_required="${found_min_required}.0";
+        done;
+        TFENV_VERSION="${found_min_required}";
+      fi;
+    fi;
+
+    TFENV_VERSION_SOURCE='terraform{required_version}'
+  fi;
+
+  if [[ -z "${TFENV_VERSION:-""}" ]]; then
+    TFENV_VERSION="$(cat "${TFENV_VERSION_FILE}" || true)" \
+      && log 'debug' "TFENV_VERSION specified in TFENV_VERSION_FILE: ${TFENV_VERSION}";
+
+    TFENV_VERSION_SOURCE="${TFENV_VERSION_FILE}";
+  fi;
 else
   TFENV_VERSION="${TFENV_TERRAFORM_VERSION}" \
     && log 'debug' "TFENV_VERSION specified in TFENV_TERRAFORM_VERSION: ${TFENV_VERSION}";

--- a/test/test_install_and_use_required_version.sh
+++ b/test/test_install_and_use_required_version.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+set -uo pipefail;
+
+####################################
+# Ensure we can execute standalone #
+####################################
+
+function early_death() {
+  echo "[FATAL] ${0}: ${1}" >&2;
+  exit 1;
+};
+
+if [ -z "${TFENV_ROOT:-""}" ]; then
+  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+  readlink_f() {
+    local target_file="${1}";
+    local file_name;
+
+    while [ "${target_file}" != "" ]; do
+      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
+      target_file="$(readlink "${file_name}")";
+    done;
+
+    echo "$(pwd -P)/${file_name}";
+  };
+
+  TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
+  [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
+else
+  TFENV_ROOT="${TFENV_ROOT%/}";
+fi;
+export TFENV_ROOT;
+
+if [ -n "${TFENV_HELPERS:-""}" ]; then
+  log 'debug' 'TFENV_HELPERS is set, not sourcing helpers again';
+else
+  [ "${TFENV_DEBUG:-0}" -gt 0 ] && echo "[DEBUG] Sourcing helpers from ${TFENV_ROOT}/lib/helpers.sh";
+  if source "${TFENV_ROOT}/lib/helpers.sh"; then
+    log 'debug' 'Helpers sourced successfully';
+  else
+    early_death "Failed to source helpers from ${TFENV_ROOT}/lib/helpers.sh";
+  fi;
+fi;
+
+#####################
+# Begin Script Body #
+#####################
+
+declare -a errors=();
+
+cleanup || log 'error' 'Cleanup failed?!';
+
+
+log 'info' '### Install required_version normal version (#.#.#)';
+
+reqv='0.14.11';
+
+echo "terraform {
+  required_version = \">=${reqv}\"
+}" > required_version.tf;
+
+(
+  tfenv install;
+  tfenv use;
+  check_active_version "${reqv}";
+) || error_and_proceed 'required_version does not match';
+
+cleanup || log 'error' 'Cleanup failed?!';
+
+
+log 'info' '### Install required_version tagged version (#.#.#-tag#)'
+
+reqv='0.14.0-rc1'
+
+echo "terraform {
+    required_version = \">=${reqv}\"
+}" > required_version.tf;
+
+(
+  tfenv install;
+  tfenv use;
+  check_active_version "${reqv}";
+) || error_and_proceed 'required_version tagged-version does not match';
+
+cleanup || log 'error' 'Cleanup failed?!';
+
+
+log 'info' '### Install required_version incomplete version (#.#.<missing>)'
+
+reqv='0.14';
+
+echo "terraform {
+  required_version = \">=${reqv}\"
+}" > required_version.tf;
+
+(
+  tfenv install;
+  tfenv use;
+  check_active_version "${reqv}.0";
+) || error_and_proceed 'required_version incomplete-version does not match';
+
+cleanup || log 'error' 'Cleanup failed?!';
+
+log 'info' '### Test auto-installing when running terraform';
+
+reqv='0.14.11';
+
+echo "terraform {
+  required_version = \">=${reqv}\"
+}" > required_version.tf;
+
+(
+  check_active_version "${reqv}";
+) || error_and_proceed 'required_version does not match';
+
+cleanup || log 'error' 'Cleanup failed?!';
+
+if [ "${#errors[@]}" -gt 0 ]; then
+  log 'warn' '===== The following required_version tests failed =====';
+  for error in "${errors[@]}"; do
+    log 'warn' "\t${error}";
+  done;
+  log 'error' 'required_version test failure(s)';
+else
+  log 'info' 'All required_version tests passed.';
+fi;
+
+exit 0;


### PR DESCRIPTION
This PR enables automatic use of [`required_version`](https://www.terraform.io/language/settings#specifying-a-required-terraform-version) setting under "terraform" section in any of .tf or tf.json files for tfenv `install` and `use` commands, and, consequentially, for `bin/terraform` wrapper itself.
The PR tries to combine the functionality present in `.terraform-version` feature, where you can just run commands without parameters and the version is automatically detected without a need to run any additional commands, and the functionality of `min-required` feature, where you can detect the version from native terraform configurations without a need to add new configuration files to existing code.

So with that, it becomes possible to just run `terraform` command against a pre-existing terraform configuration, and have a correspoinding terraform version installed and used, without any need to add new files or reconfigure CI/CD-related automations.

